### PR TITLE
Several build.m improvement/fixes for Linux.

### DIFF
--- a/build.m
+++ b/build.m
@@ -15,8 +15,22 @@ tudatTarget = 'tudat';
 testsTargetsPrefix = 'test_json_';
 
 cmakebin = '';
+% Default location on make if not installed to path
 if ismac
     cmakebin = '/Applications/CMake.app/Contents/bin/cmake';
+end
+if isunix || ismac
+    % Try to get cmake from path (UNIX)
+    [status, response] = system('which cmake');
+    if status == 0
+        cmakebin = strtrim(response);
+    end
+elseif ispc
+    % Try for Windows
+    [status, response] = system('where cmake');
+    if status == 0
+        cmakebin = strtrim(response);
+    end
 end
 if exist(cmakebin,'file') ~= 2
     cmakebin = input('Specify the absolute path to the cmake binary: ','s');
@@ -28,8 +42,8 @@ end
 
 command = [
     sprintf('cd %s; ',builddir)...
-    sprintf('%s ../tudatBundle; ',cmakebin)...
-    sprintf('%s --build . --target %s -- -j%i',cmakebin,tudatTarget,concurrentJobs)
+    sprintf('LD_LIBRARY_PATH= %s ../tudatBundle; ',cmakebin)...
+    sprintf('LD_LIBRARY_PATH= %s --build . --target %s -- -j%i',cmakebin,tudatTarget,concurrentJobs)
     ];
 
 if buildUnitTests
@@ -37,7 +51,7 @@ if buildUnitTests
     testNames = {testFiles.name};
     for i = 1:length(testNames)
         testName = strrep(testNames{i},'.m','');
-        command = sprintf('%s; %s --build . --target %s%s -- -j%i',...
+        command = sprintf('%s;LD_LIBRARY_PATH= %s --build . --target %s%s -- -j%i',...
             command,cmakebin,testsTargetsPrefix,testName,concurrentJobs);
     end
 end


### PR DESCRIPTION
LD_LIBRARY_PATH= tells the applications run using "system" command to use system libraries instead of Matlab libraries. This is often necessary as there are conflicts between the two.

Also added some code to help with cmake autodetection.